### PR TITLE
Wrap all code in generic try/except and output stacktrace to error log

### DIFF
--- a/attack.py
+++ b/attack.py
@@ -17,6 +17,7 @@ Worker for Mitre ATT&CK, using the STIX implementation available here:
 
 import os
 from logging import error, warning, info
+import traceback
 import act
 from stix2 import parse, Filter, MemoryStore
 import worker
@@ -329,9 +330,8 @@ def send_notification(notify, notifycache, smtphost, sender, recipient):
         error("--smtphost, --recipient and --sender must be set to send revoked/deprecated objects on email")
 
 
-if __name__ == '__main__':
+def main():
     args = parseargs()
-
     client = act.Act(
         args.act_baseurl,
         args.user_id,
@@ -369,3 +369,11 @@ if __name__ == '__main__':
 
         if notify:
             send_notification(notify, args.notifycache, args.smtphost, args.sender, args.recipient)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        error("Unhandled exception: {}".format(traceback.format_exc()))
+        raise

--- a/country_regions.py
+++ b/country_regions.py
@@ -3,6 +3,8 @@
 """Worker module fetching ISO 3166 from github to add is{Country,Region,SubRegion} facts,
 output result in a format understandable to ACT add fact"""
 
+from logging import error
+import traceback
 import act
 import worker
 
@@ -50,7 +52,10 @@ def process(actapi, country_list):
 if __name__ == '__main__':
     ARGS = parseargs()
 
-    actapi = act.Act(ARGS.act_baseurl, ARGS.user_id, ARGS.loglevel, ARGS.logfile, "country-region")
-    country_list = worker.fetch_json(ARGS.country_region_url, ARGS.proxy_string, ARGS.timeout)
-
-    process(actapi, country_list)
+    try:
+        actapi = act.Act(ARGS.act_baseurl, ARGS.user_id, ARGS.loglevel, ARGS.logfile, "country-region")
+        country_list = worker.fetch_json(ARGS.country_region_url, ARGS.proxy_string, ARGS.timeout)
+        process(actapi, country_list)
+    except Exception as e:
+        error("Unhandled exception: {}".format(traceback.format_exc()))
+        raise

--- a/cyber_uio.py
+++ b/cyber_uio.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 
 import argparse
 import sys
+import traceback
 import socket
 from logging import error
 import urllib3
@@ -99,4 +100,8 @@ def main():
 
 if __name__ == '__main__':
 
-    main()
+    try:
+        main()
+    except Exception as e:
+        error("Unhandled exception: {}".format(traceback.format_exc()))
+        sys.exit(1)

--- a/generic_uploader.py
+++ b/generic_uploader.py
@@ -4,6 +4,7 @@
 from the stdin, uploading accordingly"""
 
 from logging import error
+import traceback
 import argparse
 import json
 import sys
@@ -43,6 +44,9 @@ def process(actapi):
 if __name__ == '__main__':
     ARGS = parseargs()
 
-    actapi = act.Act(ARGS.act_baseurl, ARGS.user_id, ARGS.loglevel, ARGS.logfile, "generic-uploader")
-
-    process(actapi)
+    try:
+        actapi = act.Act(ARGS.act_baseurl, ARGS.user_id, ARGS.loglevel, ARGS.logfile, "generic-uploader")
+        process(actapi)
+    except Exception as e:
+        error("Unhandled exception: {}".format(traceback.format_exc()))
+        raise

--- a/misp_feeds.py
+++ b/misp_feeds.py
@@ -3,6 +3,8 @@
 and adding data to the platform"""
 
 import act
+from logging import error
+import traceback
 import argparse
 import hashlib
 import json
@@ -178,5 +180,9 @@ def main(client):
 if __name__ == "__main__":
     ARGS = parseargs()
 
-    actapi = act.Act(ARGS.act_baseurl, ARGS.act_user_id, ARGS.loglevel, ARGS.logfile, "misp-import")
-    main(actapi)
+    try:
+        actapi = act.Act(ARGS.act_baseurl, ARGS.act_user_id, ARGS.loglevel, ARGS.logfile, "misp-import")
+        main(actapi)
+    except Exception as e:
+        error("Unhandled exception: {}".format(traceback.format_exc()))
+        raise

--- a/pdns_enrichment.py
+++ b/pdns_enrichment.py
@@ -8,6 +8,7 @@ import argparse
 import socket
 import sys
 from logging import warning, error
+import traceback
 import urllib3
 import requests
 import act
@@ -167,6 +168,9 @@ class UnknownResult(Exception):
 if __name__ == '__main__':
     ARGS = parseargs()
 
-    actapi = act.Act(ARGS.act_baseurl, ARGS.user_id, ARGS.loglevel, ARGS.logfile, "pdns-enrichment")
-
-    process(actapi, ARGS.pdns_baseurl, ARGS.apikey, ARGS.timeout)
+    try:
+        actapi = act.Act(ARGS.act_baseurl, ARGS.user_id, ARGS.loglevel, ARGS.logfile, "pdns-enrichment")
+        process(actapi, ARGS.pdns_baseurl, ARGS.apikey, ARGS.timeout)
+    except Exception as e:
+        error("Unhandled exception: {}".format(traceback.format_exc()))
+        raise

--- a/scio-worker.py
+++ b/scio-worker.py
@@ -6,6 +6,7 @@ import sys
 import argparse
 import json
 from logging import error
+import traceback
 
 import act
 
@@ -69,7 +70,6 @@ def add_to_act(actapi, doc):
     except act.base.ResponseError as e:
         error("Unable to create fact: %s" % e)
 
-
     indicators = doc.get("indicators", {})
 
     # Loop over all items under indicators in report
@@ -118,7 +118,10 @@ def add_to_act(actapi, doc):
 if __name__ == '__main__':
     ARGS = parseargs()
 
-    actapi = act.Act(ARGS.act_baseurl, ARGS.act_user_id, ARGS.loglevel, ARGS.logfile, "scio")
-
-    # Add IOCs from reports to the ACT platform
-    add_to_act(actapi, get_scio_report())
+    try:
+        actapi = act.Act(ARGS.act_baseurl, ARGS.act_user_id, ARGS.loglevel, ARGS.logfile, "scio")
+        # Add IOCs from reports to the ACT platform
+        add_to_act(actapi, get_scio_report())
+    except Exception as e:
+        error("Unhandled exception: {}".format(traceback.format_exc()))
+        raise

--- a/vt.py
+++ b/vt.py
@@ -32,6 +32,8 @@ import ipaddress
 import re
 import sys
 import warnings
+from logging import error
+import traceback
 import act
 from functools import partialmethod
 
@@ -290,4 +292,8 @@ def no_ssl_verification():
 
 if __name__ == '__main__':
 
-    main()
+    try:
+        main()
+    except Exception as e:
+        error("Unhandled exception: {}".format(traceback.format_exc()))
+        raise


### PR DESCRIPTION
Wrap main code in generic try/except to make sure all error are outputed to error log.