### PR TITLE
bug: reference before use in case of no enrichment registered

### DIFF
--- a/misp_feeds.py
+++ b/misp_feeds.py
@@ -132,6 +132,7 @@ def main(client):
     """program entry point"""
 
     verify_dir()
+    status = {}  # in case of empty feed/no enrichment uploads.
 
     with open("misp/misp_feeds.txt") as f:
         for line in f:


### PR DESCRIPTION
bugfix. Reference before use on last status line output when there are no registered enrichments during the run.