### PR TITLE
Refactor misp_feeds

### DIFF
--- a/etc/actworkers.ini
+++ b/etc/actworkers.ini
@@ -14,25 +14,17 @@ port =
 # the data post inspection. Without the proper certificate,
 # you will get a certificate error.
 
-# file = /home/nifi/cacert.pem
-file =
+# file = 
 
 [misp]
-# Valid loglevels are currently "info" and "none"
-
-# loglevel =
+# loglevel = none
 loglevel = info
-
-# The default "logfile" is stdout
-
-# logfile =
-logfile = /home/nifi/workerlog/misp.log
 
 # The manifest directory stores the latest manifest files
 # for the misp feeds, allowing for only partial downloads
-# of the data
+# of the data. Default $XDG_CACHE_HOME/misp_manifest.
 
-manifest_dir = /home/nifi/workers/misp/manifest
+# manifest_dir = 
 
 [misp_enrich]
 # These are the endpoints on the nifi instanse that handles

--- a/misp/misp_feeds.txt
+++ b/misp/misp_feeds.txt
@@ -1,1 +1,0 @@
-https://www.circl.lu/doc/misp/feed-osint/

--- a/setup.py
+++ b/setup.py
@@ -21,20 +21,21 @@ setup(
     keywords="ACT, mnemonic",
     entry_points={
         'console_scripts': [
-            'act-vt = act_worker.vt:main_log_error',
-            'act-attack = act_worker.attack:main_log_error',
-            'act-mnemonic-pdns = act_worker.mnemonic_pdns:main_log_error',
-            'act-country-regions = act_worker.country_regions:main_log_error',
-            'act-cyber-uio = act_worker.cyber_uio:main_log_error',
-            'act-misp-feeds = act_worker.misp_feeds:main_log_error',
-            'act-scio = act_worker.scio:main_log_error',
-            'act-uploader = act_worker.generic_uploader:main_log_error',
-            'act-shadowserver-asn = act_worker.shadowserver_asn:main_log_error',
+            'act-vt = act_workers.vt:main_log_error',
+            'act-attack = act_workers.attack:main_log_error',
+            'act-mnemonic-pdns = act_workers.mnemonic_pdns:main_log_error',
+            'act-country-regions = act_workers.country_regions:main_log_error',
+            'act-cyber-uio = act_workers.cyber_uio:main_log_error',
+            'act-misp-feeds = act_workers.misp_feeds:main_log_error',
+            'act-scio = act_workers.scio:main_log_error',
+            'act-uploader = act_workers.generic_uploader:main_log_error',
+            'act-shadowserver-asn = act_workers.shadowserver_asn:main_log_error',
         ]
     },
     packages=["act_workers", "act_workers_libs"],
+    data_files=[('/etc/', ['etc/actworkers.ini'])],
     url="https://github.com/mnemonic-no/act-workers",
-    install_requires=['act-api>=0.5.3', 'requests', 'RashlyOutlaid', 'virustotal-api', 'stix2'],
+    install_requires=['act-api>=0.5.4', 'requests', 'RashlyOutlaid', 'virustotal-api', 'stix2'],
 
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
     classifiers=[


### PR DESCRIPTION
Moved argparsing into worker.py
taken some of the configuration out of the .ini file (using worker.py
standard)
adding facts using handle_fact
handling of cache dir using worker.get_cache_dir if no manifest dir is
specified in the ini file
setuptools: copying the actworkers.ini to /etc
setuptools: bump of act-api version requirement
setuptools: bugfix (act_worker. -> act_workers. for entry points)