### PR TITLE
add batch size parameter for pdns requests

### DIFF
--- a/act/workers/etc/actworkers.ini
+++ b/act/workers/etc/actworkers.ini
@@ -107,6 +107,9 @@
 ### PDNS apikey
 # pdns-apikey =
 
+### Batch size of pDNS queries
+# pdns-batch-size = 500
+
 [scio]
 # No worker specific options
 

--- a/act/workers/etc/actworkers.ini
+++ b/act/workers/etc/actworkers.ini
@@ -108,7 +108,7 @@
 # pdns-apikey =
 
 ### Batch size of pDNS queries
-# pdns-batch-size = 500
+# pdns-batch-size = 1000
 
 [scio]
 # No worker specific options

--- a/act/workers/libs/mnemonic.py
+++ b/act/workers/libs/mnemonic.py
@@ -14,7 +14,8 @@ def batch_query(
         headers: Optional[Dict] = None,
         timeout: int = 299,
         json_params: Optional[Dict] = None,
-        proxy_string: Optional[Text] = None) -> Generator[Dict[Text, Any], None, None]:
+        proxy_string: Optional[Text] = None,
+        batch_size: int = 250) -> Generator[Dict[Text, Any], None, None]:
     """ Execute query until we have all results """
 
     offset = 0
@@ -38,8 +39,10 @@ def batch_query(
 
         if method == "POST" and json_params:
             json_params["offset"] = offset
+            json_params["limit"] = batch_size
         elif method == "GET":
             options["params"]["offset"] = offset  # type: ignore
+            options["params"]["limit"] = batch_size
 
         debug("Executing search: {}, json={}, options={}".format(url, json_params, options))
         req = requests.request(method, url, json=json_params, **options)  # type:ignore

--- a/act/workers/libs/mnemonic.py
+++ b/act/workers/libs/mnemonic.py
@@ -15,7 +15,7 @@ def batch_query(
         timeout: int = 299,
         json_params: Optional[Dict] = None,
         proxy_string: Optional[Text] = None,
-        batch_size: int = 250) -> Generator[Dict[Text, Any], None, None]:
+        batch_size: int = 1000) -> Generator[Dict[Text, Any], None, None]:
     """ Execute query until we have all results """
 
     offset = 0

--- a/act/workers/mnemonic_pdns.py
+++ b/act/workers/mnemonic_pdns.py
@@ -28,7 +28,7 @@ def parseargs() -> argparse.ArgumentParser:
     parser.add_argument('--pdns-timeout', dest='timeout', type=int,
                         default=299, help="Timeout")
     parser.add_argument('--pdns-batch-size', dest='pdns_batch_size', type=int,
-                        default=500, help="Batch size of pdns queries")
+                        default=1000, help="Batch size of pdns queries")
     parser.add_argument('--pdns-apikey', dest='apikey',
                         help="PassiveDNS API key")
 
@@ -41,7 +41,7 @@ def pdns_query(
         query: str,
         timeout: int,
         proxy_string: Optional[Text] = None,
-        batch_size: int = 500) -> Generator[Dict[str, Any], None, None]:
+        batch_size: int = 1000) -> Generator[Dict[str, Any], None, None]:
     """Query the passivedns result of an address.
     pdns_baseurl - the url to the passivedns api (https://api.mnemonic.no)
     apikey - PassiveDNS API key with the passivedns role (minimum)
@@ -83,7 +83,7 @@ def process(
         timeout: int = 299,
         proxy_string: Optional[Text] = None,
         output_format: Text = "json",
-        batch_size: int = 500) -> None:
+        batch_size: int = 1000) -> None:
     """Read queries from stdin, resolve each one through passivedns
     printing generic_uploader data to stdout"""
 

--- a/act/workers/mnemonic_pdns.py
+++ b/act/workers/mnemonic_pdns.py
@@ -27,6 +27,8 @@ def parseargs() -> argparse.ArgumentParser:
                         default="https://api.mnemonic.no/", help="PassiveDNS API host")
     parser.add_argument('--pdns-timeout', dest='timeout', type=int,
                         default=299, help="Timeout")
+    parser.add_argument('--pdns-batch-size', dest='pdns_batch_size', type=int,
+                        default=500, help="Batch size of pdns queries")
     parser.add_argument('--pdns-apikey', dest='apikey',
                         help="PassiveDNS API key")
 
@@ -38,7 +40,8 @@ def pdns_query(
         apikey: str,
         query: str,
         timeout: int,
-        proxy_string: Optional[Text] = None) -> Generator[Dict[str, Any], None, None]:
+        proxy_string: Optional[Text] = None,
+        batch_size: int = 500) -> Generator[Dict[str, Any], None, None]:
     """Query the passivedns result of an address.
     pdns_baseurl - the url to the passivedns api (https://api.mnemonic.no)
     apikey - PassiveDNS API key with the passivedns role (minimum)
@@ -63,7 +66,9 @@ def pdns_query(
             "GET",
             pdns_url,
             headers=headers,
-            timeout=timeout, proxy_string=proxy_string)
+            timeout=timeout,
+            proxy_string=proxy_string,
+            batch_size=batch_size)
 
     except (urllib3.exceptions.ReadTimeoutError,
             requests.exceptions.ReadTimeout,
@@ -77,7 +82,8 @@ def process(
         apikey: str,
         timeout: int = 299,
         proxy_string: Optional[Text] = None,
-        output_format: Text = "json") -> None:
+        output_format: Text = "json",
+        batch_size: int = 500) -> None:
     """Read queries from stdin, resolve each one through passivedns
     printing generic_uploader data to stdout"""
 
@@ -86,7 +92,13 @@ def process(
         if not query:
             continue
 
-        for row in pdns_query(pdns_baseurl, apikey, timeout=timeout, query=query, proxy_string=proxy_string):
+        for row in pdns_query(
+                pdns_baseurl,
+                apikey,
+                timeout=timeout,
+                query=query,
+                proxy_string=proxy_string,
+                batch_size=batch_size):
             rrtype = row["rrtype"]
 
             if rrtype in ("a", "aaaa"):
@@ -115,7 +127,13 @@ def main() -> None:
     args = worker.handle_args(parseargs())
     actapi = worker.init_act(args)
 
-    process(actapi, args.pdns_baseurl, args.apikey, args.timeout, args.proxy_string, args.output_format)
+    process(actapi,
+            args.pdns_baseurl,
+            args.apikey,
+            args.timeout,
+            args.proxy_string,
+            args.output_format,
+            args.pdns_batch_size)
 
 
 def main_log_error() -> None:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-workers",
-    version="1.0.16",
+    version="1.0.17",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",


### PR DESCRIPTION
Make batch-size for argus requets configurable and set default limit to 500 for the pDNS worker.